### PR TITLE
Fixed incorrect parameters for mumble update_groups call

### DIFF
--- a/services/modules/mumble/tests.py
+++ b/services/modules/mumble/tests.py
@@ -147,6 +147,7 @@ class MumbleViewsTestCase(TestCase):
         self.assertEqual(mumble_user.username, expected_username)
         self.assertTrue(mumble_user.pwhash)
         self.assertEqual(self.member.mumble.username, expected_username)
+        self.assertEqual('Member', mumble_user.groups)
 
     def test_deactivate(self):
         self.login()

--- a/services/modules/mumble/views.py
+++ b/services/modules/mumble/views.py
@@ -41,7 +41,7 @@ def activate_mumble(request):
 
     if result:
         logger.debug("Updated authserviceinfo for user %s with mumble credentials. Updating groups." % request.user)
-        MumbleTasks.update_groups.apply(request.user.pk)  # Run synchronously to prevent timing issues
+        MumbleTasks.update_groups.apply(args=(request.user.pk,))  # Run synchronously to prevent timing issues
         logger.info("Successfully activated mumble for user %s" % request.user)
         messages.success(request, 'Activated Mumble account.')
         credentials = {


### PR DESCRIPTION
Celery `Task.apply` takes different arguments to `Task.delay` but unfortunately doesn't throw an exception when you get it wrong and it was failing silently.

Added test to ensure member groups are correctly applied after `activate_mumble` is called.