### PR TITLE
Specify short names for service tasks

### DIFF
--- a/services/modules/discord/tasks.py
+++ b/services/modules/discord/tasks.py
@@ -60,7 +60,7 @@ class DiscordTasks:
             return True
 
     @staticmethod
-    @app.task(bind=True)
+    @app.task(bind=True, name='discord.update_groups')
     def update_groups(task_self, pk):
         user = User.objects.get(pk=pk)
         logger.debug("Updating discord groups for user %s" % user)
@@ -86,14 +86,14 @@ class DiscordTasks:
             logger.debug("User does not have a discord account, skipping")
 
     @staticmethod
-    @app.task
+    @app.task(name='discord.update_all_groups')
     def update_all_groups():
         logger.debug("Updating ALL discord groups")
         for discord_user in DiscordUser.objects.exclude(uid__exact=''):
             DiscordTasks.update_groups.delay(discord_user.user.pk)
 
     @staticmethod
-    @app.task(bind=True)
+    @app.task(bind=True, name='discord.update_nickname')
     def update_nickname(self, pk):
         user = User.objects.get(pk=pk)
         logger.debug("Updating discord nickname for user %s" % user)
@@ -114,7 +114,7 @@ class DiscordTasks:
             logger.debug("User %s does not have a discord account" % user)
 
     @staticmethod
-    @app.task
+    @app.task(name='discord.update_all_nicknames')
     def update_all_nicknames():
         logger.debug("Updating ALL discord nicknames")
         for discord_user in DiscordUser.objects.exclude(uid__exact=''):

--- a/services/modules/discourse/tasks.py
+++ b/services/modules/discourse/tasks.py
@@ -43,7 +43,7 @@ class DiscourseTasks:
             return False
 
     @staticmethod
-    @app.task(bind=True)
+    @app.task(bind=True, name='discourse.update_groups')
     def update_groups(self, pk):
         user = User.objects.get(pk=pk)
         logger.debug("Updating discourse groups for user %s" % user)
@@ -55,7 +55,7 @@ class DiscourseTasks:
         logger.debug("Updated user %s discourse groups." % user)
 
     @staticmethod
-    @app.task
+    @app.task(name='discourse.update_all_groups')
     def update_all_groups():
         logger.debug("Updating ALL discourse groups")
         for discourse_user in DiscourseUser.objects.filter(enabled=True):

--- a/services/modules/ipboard/tasks.py
+++ b/services/modules/ipboard/tasks.py
@@ -36,7 +36,7 @@ class IpboardTasks:
             return False
 
     @staticmethod
-    @app.task(bind=True)
+    @app.task(bind=True, name='ipboard.update_groups')
     def update_groups(self, pk):
         user = User.objects.get(pk=pk)
         logger.debug("Updating user %s ipboard groups." % user)
@@ -54,14 +54,13 @@ class IpboardTasks:
         logger.debug("Updated user %s ipboard groups." % user)
 
     @staticmethod
-    @app.task
+    @app.task(name='ipboard.update_all_groups')
     def update_all_groups():
         logger.debug("Updating ALL ipboard groups")
         for ipboard_user in IpboardUser.objects.exclude(username__exact=''):
             IpboardTasks.update_groups.delay(ipboard_user.user.pk)
 
     @staticmethod
-    @app.task
     def disable():
         if settings.ENABLE_AUTH_IPBOARD:
             logger.warn(

--- a/services/modules/mumble/tasks.py
+++ b/services/modules/mumble/tasks.py
@@ -34,7 +34,7 @@ class MumbleTasks:
         MumbleUser.objects.all().delete()
 
     @staticmethod
-    @app.task(bind=True)
+    @app.task(bind=True, name="mumble.update_groups")
     def update_groups(self, pk):
         user = User.objects.get(pk=pk)
         logger.debug("Updating mumble groups for user %s" % user)
@@ -56,7 +56,7 @@ class MumbleTasks:
             logger.debug("User %s does not have a mumble account, skipping" % user)
 
     @staticmethod
-    @app.task
+    @app.task(name="mumble.update_all_groups")
     def update_all_groups():
         logger.debug("Updating ALL mumble groups")
         for mumble_user in MumbleUser.objects.exclude(username__exact=''):

--- a/services/modules/openfire/tasks.py
+++ b/services/modules/openfire/tasks.py
@@ -47,7 +47,7 @@ class OpenfireTasks:
         OpenfireUser.objects.all().delete()
 
     @staticmethod
-    @app.task(bind=True)
+    @app.task(bind=True, name="openfire.update_groups")
     def update_groups(self, pk):
         user = User.objects.get(pk=pk)
         logger.debug("Updating jabber groups for user %s" % user)
@@ -68,7 +68,7 @@ class OpenfireTasks:
             logger.debug("User does not have an openfire account")
 
     @staticmethod
-    @app.task
+    @app.task(name="openfire.update_all_groups")
     def update_all_groups():
         logger.debug("Updating ALL jabber groups")
         for openfire_user in OpenfireUser.objects.exclude(username__exact=''):

--- a/services/modules/phpbb3/tasks.py
+++ b/services/modules/phpbb3/tasks.py
@@ -37,7 +37,7 @@ class Phpbb3Tasks:
             return False
 
     @staticmethod
-    @app.task(bind=True)
+    @app.task(bind=True, name="phpbb3.update_groups")
     def update_groups(self, pk):
         user = User.objects.get(pk=pk)
         logger.debug("Updating phpbb3 groups for user %s" % user)
@@ -58,7 +58,7 @@ class Phpbb3Tasks:
             logger.debug("User does not have a Phpbb3 account")
 
     @staticmethod
-    @app.task
+    @app.task(name="phpbb3.update_all_groups")
     def update_all_groups():
         logger.debug("Updating ALL phpbb3 groups")
         for user in Phpbb3User.objects.exclude(username__exact=''):

--- a/services/modules/smf/tasks.py
+++ b/services/modules/smf/tasks.py
@@ -47,7 +47,7 @@ class SmfTasks:
         SmfUser.objects.all().delete()
 
     @staticmethod
-    @app.task(bind=True)
+    @app.task(bind=True, name="smf.update_groups")
     def update_groups(self, pk):
         user = User.objects.get(pk=pk)
         logger.debug("Updating smf groups for user %s" % user)
@@ -68,7 +68,7 @@ class SmfTasks:
             logger.debug("User does not have an smf account")
 
     @staticmethod
-    @app.task
+    @app.task(name="smf.update_all_groups")
     def update_all_groups():
         logger.debug("Updating ALL smf groups")
         for user in SmfUser.objects.exclude(username__exact=''):

--- a/services/modules/teamspeak3/tasks.py
+++ b/services/modules/teamspeak3/tasks.py
@@ -65,7 +65,7 @@ class Teamspeak3Tasks:
         logger.info("Teamspeak3 disabled")
 
     @staticmethod
-    @app.task(bind=True)
+    @app.task(bind=True, name="teamspeak3.update_groups")
     def update_groups(self, pk):
         user = User.objects.get(pk=pk)
         logger.debug("Updating user %s teamspeak3 groups" % user)
@@ -89,7 +89,7 @@ class Teamspeak3Tasks:
             logger.debug("User does not have a teamspeak3 account")
 
     @staticmethod
-    @app.task
+    @app.task(name="teamspeak3.update_all_groups")
     def update_all_groups():
         logger.debug("Updating ALL teamspeak3 groups")
         for user in Teamspeak3User.objects.exclude(uid__exact=''):


### PR DESCRIPTION
Quality of life improvement.

Running tasks manually from a celery shell (`python manage.py celery shell`) can be achieved by running `app.send_task('service_name.task_name')`.

Previously it was possible to run `service_task_name()` to execute a task from a celery task, however as they share a common function name this method clashes with other services, so the new method should be used in place of this.