### PR TITLE
Prevent HR search from failing with None alliance_name

### DIFF
--- a/hrapplications/views.py
+++ b/hrapplications/views.py
@@ -231,14 +231,15 @@ def hr_application_search(request):
                         applications.add(application)
                     if searchstring in application.main_character.corporation_name.lower():
                         applications.add(application)
-                    if searchstring in application.main_character.alliance_name.lower():
+                    if application.main_character.alliance_name \
+                            and searchstring in application.main_character.alliance_name.lower():
                         applications.add(application)
                 for character in application.characters:
                     if searchstring in character.character_name.lower():
                         applications.add(application)
                     if searchstring in character.corporation_name.lower():
                         applications.add(application)
-                    if searchstring in character.alliance_name.lower():
+                    if character.alliance_name and searchstring in character.alliance_name.lower():
                         applications.add(application)
                 if searchstring in application.user.username.lower():
                     applications.add(application)


### PR DESCRIPTION
Reported by a user via gitter.

When a character is not in an alliance the search fails as `alliance_name` is None. Since v1.14.2 `alliance_id` and `alliance_name` are now defaulting to `None` instead of an empty string, which I'm fine with.

I searched around for any other similar calls to these two attributes but couldn't find any.