### PR TITLE
Implement Openfire username escaping

### DIFF
--- a/services/modules/openfire/manager.py
+++ b/services/modules/openfire/manager.py
@@ -38,23 +38,24 @@ class OpenfireManager:
 
     @staticmethod
     def __sanitize_username(username):
-        # https://xmpp.org/extensions/xep-0029.html#sect-idp625072
+        # https://xmpp.org/extensions/xep-0106.html#escaping
         replace = [
-            ("\"", ""),
-            ("&", ""),
-            ("'", ""),
-            ("/", ""),
-            (":", ""),
-            ("<", ""),
-            (">", ""),
-            ("@", ""),
+            ("\\", "\\5c"),  # Escape backslashes first to double escape existing escape sequences
+            ("\"", "\\22"),
+            ("&", "\\26"),
+            ("'", "\\27"),
+            ("/", "\\2f"),
+            (":", "\\3a"),
+            ("<", "\\3c"),
+            (">", "\\3e"),
+            ("@", "\\40"),
             ("\u007F", ""),
             ("\uFFFE", ""),
             ("\uFFFF", ""),
-            (" ", "_"),  # Catch spaces last in case its introduced elsewhere
+            (" ", "\\20"),
         ]
 
-        sanitized = username.lower()
+        sanitized = username.strip(' ')
 
         for find, rep in replace:
             sanitized = sanitized.replace(find, rep)

--- a/services/modules/openfire/tests.py
+++ b/services/modules/openfire/tests.py
@@ -207,8 +207,8 @@ class OpenfireManagerTestCase(TestCase):
         self.assertIsInstance(password, type(''))
 
     def test__sanitize_username(self):
-        test_username = "My_Test User\"'&/:<>@\u007F\uFFFE\uFFFFname"
+        test_username = " My_Test User\"'&/:<>@name\\20name"
 
         result_username = self.manager._OpenfireManager__sanitize_username(test_username)
 
-        self.assertEqual(result_username, 'my_test_username')
+        self.assertEqual(result_username, 'My_Test\\20User\\22\\27\\26\\2f\\3a\\3c\\3e\\40name\\5c20name')

--- a/services/modules/openfire/tests.py
+++ b/services/modules/openfire/tests.py
@@ -205,3 +205,10 @@ class OpenfireManagerTestCase(TestCase):
 
         self.assertEqual(len(password), 16)
         self.assertIsInstance(password, type(''))
+
+    def test__sanitize_username(self):
+        test_username = "My_Test User\"'&/:<>@\u007F\uFFFE\uFFFFname"
+
+        result_username = self.manager._OpenfireManager__sanitize_username(test_username)
+
+        self.assertEqual(result_username, 'my_test_username')


### PR DESCRIPTION
Fixes #699 

Provides XEP-106 compliant username escaping. Openfire supports XEP-106. Other clients which do not currently support XEP-106 may show the escape characters instead of the correct characters. Go bug the clients developers.