### PR TITLE
IPS4 and Market PHP hash fix

### DIFF
--- a/services/forms.py
+++ b/services/forms.py
@@ -22,7 +22,7 @@ class FleetFormatterForm(forms.Form):
 
 
 class ServicePasswordForm(forms.Form):
-    password = forms.CharField(label=_("Password"), required=True)
+    password = forms.CharField(label=_("Password"), required=True, widget=forms.PasswordInput())
 
     def clean_password(self):
         password = self.cleaned_data['password']

--- a/services/modules/ips4/manager.py
+++ b/services/modules/ips4/manager.py
@@ -48,7 +48,7 @@ class Ips4Manager:
 
     @staticmethod
     def _gen_pwhash(password):
-        return bcrypt.using(ident='2a').encrypt(password.encode('utf-8'), rounds=13)
+        return bcrypt.using(ident='2y').encrypt(password.encode('utf-8'), rounds=13)
 
     @staticmethod
     def _get_salt(pw_hash):

--- a/services/modules/market/manager.py
+++ b/services/modules/market/manager.py
@@ -38,7 +38,7 @@ class MarketManager:
 
     @staticmethod
     def _gen_pwhash(password):
-        return bcrypt.encrypt(password.encode('utf-8'), rounds=13)
+        return bcrypt.using(ident='2y').encrypt(password.encode('utf-8'), rounds=13)
 
     @staticmethod
     def _get_salt(pw_hash):

--- a/stock/templates/registered/service_password.html
+++ b/stock/templates/registered/service_password.html
@@ -14,7 +14,6 @@
         <div class="container-fluid">
             <div class="col-md-4 col-md-offset-4">
                 <div class="row">
-                    <p>{% trans "Passwords are stored as plain text. Don't re-use another password." %}</p>
                     <form class="form-signin" role="form" action="" method="POST"
                           onsubmit="submitbutton.disabled = true; return true;">
                         {% csrf_token %}


### PR DESCRIPTION
Fixes #700

Corrects unsupported `2b` hashes for older versions of PHP. While you could update PHP to get support, there's nothing (presently) wrong with using `2y` in PHP. If you have a _really_ old version of PHP that doesn't support `2y`, then you need to upgrade.

Also removes warnings about plaintext passwords, which no service has anymore, and changes the custom password field from text to password.

I'll attempt to backport the hash fix to 1.14. Edit: Would be a very big change to backport. If you need these fixes you can probably copy the 1.15 manager over the 1.14 manager.