### PR TITLE
Teamspeak 3 Updates

### DIFF
--- a/services/modules/teamspeak3/forms.py
+++ b/services/modules/teamspeak3/forms.py
@@ -10,6 +10,7 @@ class TeamspeakJoinForm(forms.Form):
     username = forms.CharField(widget=forms.HiddenInput())
 
     def clean(self):
-        if Teamspeak3Manager._get_userid(self.cleaned_data['username']):
-            return self.cleaned_data
+        with Teamspeak3Manager() as ts3man:
+            if ts3man._get_userid(self.cleaned_data['username']):
+                return self.cleaned_data
         raise forms.ValidationError(_("Unable to locate user %s on server") % self.cleaned_data['username'])

--- a/services/modules/teamspeak3/util/ts3.py
+++ b/services/modules/teamspeak3/util/ts3.py
@@ -50,13 +50,24 @@ class TS3Proto:
             return True
 
     def disconnect(self):
-        self.send_command("quit")
-        self._conn.close()
-        self._connected = False
-        self._log.info('Disconnected')
+        if self._connected:
+            try:
+                self.send("quit")
+                self._conn.close()
+            except:
+                self._log.exception('Error while disconnecting')
+            self._connected = False
+            self._log.info('Disconnected')
+        else:
+            self._log.info("Not connected")
 
     def send_command(self, command, keys=None, opts=None):
         cmd = self.construct_command(command, keys=keys, opts=opts)
+
+        # Clear read buffer of any stray bytes
+        self._conn.read_very_eager()
+
+        # Send command
         self.send('%s\n' % cmd)
 
         data = []

--- a/services/modules/teamspeak3/views.py
+++ b/services/modules/teamspeak3/views.py
@@ -28,17 +28,17 @@ def activate_teamspeak3(request):
     authinfo = AuthServicesInfo.objects.get(user=request.user)
     character = EveManager.get_main_character(request.user)
     ticker = character.corporation_ticker
-
-    if authinfo.state == BLUE_STATE:
-        logger.debug("Adding TS3 user for blue user %s with main character %s" % (request.user, character))
-        # Blue members should have alliance ticker (if in alliance)
-        if EveAllianceInfo.objects.filter(alliance_id=character.alliance_id).exists():
-            alliance = EveAllianceInfo.objects.filter(alliance_id=character.alliance_id)[0]
-            ticker = alliance.alliance_ticker
-        result = Teamspeak3Manager.add_blue_user(character.character_name, ticker)
-    else:
-        logger.debug("Adding TS3 user for user %s with main character %s" % (request.user, character))
-        result = Teamspeak3Manager.add_user(character.character_name, ticker)
+    with Teamspeak3Manager() as ts3man:
+        if authinfo.state == BLUE_STATE:
+            logger.debug("Adding TS3 user for blue user %s with main character %s" % (request.user, character))
+            # Blue members should have alliance ticker (if in alliance)
+            if EveAllianceInfo.objects.filter(alliance_id=character.alliance_id).exists():
+                alliance = EveAllianceInfo.objects.filter(alliance_id=character.alliance_id)[0]
+                ticker = alliance.alliance_ticker
+            result = ts3man.add_blue_user(character.character_name, ticker)
+        else:
+            logger.debug("Adding TS3 user for user %s with main character %s" % (request.user, character))
+            result = ts3man.add_user(character.character_name, ticker)
 
     # if its empty we failed
     if result[0] is not "":
@@ -97,18 +97,19 @@ def reset_teamspeak3_perm(request):
     authinfo = AuthServicesInfo.objects.get(user=request.user)
     character = EveManager.get_main_character(request.user)
     logger.debug("Deleting TS3 user for user %s" % request.user)
-    Teamspeak3Manager.delete_user(request.user.teamspeak3.uid)
+    with Teamspeak3Manager() as ts3man:
+        ts3man.delete_user(request.user.teamspeak3.uid)
 
-    if authinfo.state == BLUE_STATE:
-        logger.debug(
-            "Generating new permission key for blue user %s with main character %s" % (request.user, character))
-        result = Teamspeak3Manager.generate_new_blue_permissionkey(request.user.teamspeak3.uid,
-                                                                   character.character_name,
-                                                                   character.corporation_ticker)
-    else:
-        logger.debug("Generating new permission key for user %s with main character %s" % (request.user, character))
-        result = Teamspeak3Manager.generate_new_permissionkey(request.user.teamspeak3.uid, character.character_name,
-                                                              character.corporation_ticker)
+        if authinfo.state == BLUE_STATE:
+            logger.debug(
+                "Generating new permission key for blue user %s with main character %s" % (request.user, character))
+            result = ts3man.generate_new_blue_permissionkey(request.user.teamspeak3.uid,
+                                                            character.character_name,
+                                                            character.corporation_ticker)
+        else:
+            logger.debug("Generating new permission key for user %s with main character %s" % (request.user, character))
+            result = ts3man.generate_new_permissionkey(request.user.teamspeak3.uid, character.character_name,
+                                                       character.corporation_ticker)
 
     # if blank we failed
     if result[0] != "":

--- a/services/modules/teamspeak3/views.py
+++ b/services/modules/teamspeak3/views.py
@@ -82,8 +82,9 @@ def deactivate_teamspeak3(request):
     if Teamspeak3Tasks.has_account(request.user) and Teamspeak3Tasks.delete_user(request.user):
         logger.info("Successfully deactivated TS3 for user %s" % request.user)
         messages.success(request, 'Deactivated TeamSpeak3 account.')
-    logger.error("Unsuccessful attempt to deactivate TS3 for user %s" % request.user)
-    messages.error(request, 'An error occurred while processing your TeamSpeak3 account.')
+    else:
+        logger.error("Unsuccessful attempt to deactivate TS3 for user %s" % request.user)
+        messages.error(request, 'An error occurred while processing your TeamSpeak3 account.')
     return redirect("auth_services")
 
 


### PR DESCRIPTION
Converts manager to instance based instead of static. This allows a single connection to be reused. The class also now makes use of the `__enter__` and `__exit__` magic methods, allowing it to be used with a `with` clause. When the `with` block exits, the connection is automatically torn down instead of being left dangling as it was previously.

This also attempts to address #713, partially by ensuring the connections are closed when they're completed and also by ensuring the response buffer is clear before sending new commands. I'm not particularly hopeful of it being addressed by this though. In my testing I could open up about 1600 TCP connections (in various connection states) to teamspeak running the affected command without any problems. I also think its very unlikely that an entire command is sitting in the buffer, though its possible.

Also fixed a minor display issue where a user disabling an account would always receive an error message regardless of the success state.