### PR TITLE
Update Openfire broadcast tool

### DIFF
--- a/docs/installation/auth/settings.md
+++ b/docs/installation/auth/settings.md
@@ -68,6 +68,7 @@ If using Openfire, the following need to be set in accordance with the [install 
  - [BROADCAST_USER](#broadcast-user)
  - [BROADCAST_USER_PASSWORD](#broadcast-user-password)
  - [BROADCAST_SERVICE_NAME](#broadcast-service-name)
+ - [BROADCAST_IGNORE_INVALID_CERT](#broadcast-ignore-invalid-cert)
 
 ### Mumble
 If using Mumble, the following needs to be set to the address of the mumble server:

--- a/docs/installation/services/openfire.md
+++ b/docs/installation/services/openfire.md
@@ -82,6 +82,8 @@ Navigate to the `Server` tab, `Server Manager` subtab, and select `System Proper
  - Name: `plugin.broadcast.allowedUsers`
    - Value: `broadcast@example.com`, replacing the domain name with yours
    - Do not encrypt this property value
+   
+If you have troubles getting broadcasts to work, you can try setting the optional (you will need to add it) `BROADCAST_IGNORE_INVALID_CERT` setting to `True`. This will allow invalid certificates to be used when connecting to the Openfire server to send a broadcast.
 
 ### Group Chat
 Channels are available which function like a chat room. Access can be controlled either by password or ACL (not unlike mumble).

--- a/services/modules/openfire/views.py
+++ b/services/modules/openfire/views.py
@@ -10,7 +10,7 @@ from eveonline.managers import EveManager
 from eveonline.models import EveCharacter
 from services.forms import ServicePasswordForm
 
-from .manager import OpenfireManager
+from .manager import OpenfireManager, PingBotException
 from .tasks import OpenfireTasks
 from .forms import JabberBroadcastForm
 from .models import OpenfireUser
@@ -103,27 +103,29 @@ def jabber_broadcast_view(request):
         if form.is_valid():
             main_char = EveManager.get_main_character(request.user)
             logger.debug("Processing jabber broadcast for user %s with main character %s" % (request.user, main_char))
-            if main_char is not None:
-                message_to_send = form.cleaned_data[
-                                      'message'] + "\n##### SENT BY: " + "[" + main_char.corporation_ticker + "]" + \
-                                  main_char.character_name + " TO: " + \
-                                  form.cleaned_data['group'] + " WHEN: " + datetime.datetime.utcnow().strftime(
-                    "%Y-%m-%d %H:%M:%S") + " #####\n##### Replies are NOT monitored #####\n"
-                group_to_send = form.cleaned_data['group']
+            try:
+                if main_char is not None:
+                    message_to_send = form.cleaned_data[
+                                          'message'] + "\n##### SENT BY: " + "[" + main_char.corporation_ticker + "]" + \
+                                      main_char.character_name + " TO: " + \
+                                      form.cleaned_data['group'] + " WHEN: " + datetime.datetime.utcnow().strftime(
+                        "%Y-%m-%d %H:%M:%S") + " #####\n##### Replies are NOT monitored #####\n"
+                    group_to_send = form.cleaned_data['group']
 
-                OpenfireManager.send_broadcast_threaded(group_to_send, message_to_send, )
+                else:
+                    message_to_send = form.cleaned_data[
+                        'message'] + "\n##### SENT BY: " + "No character but can send pings?" + " TO: " + \
+                        form.cleaned_data['group'] + " WHEN: " + datetime.datetime.utcnow().strftime(
+                        "%Y-%m-%d %H:%M:%S") + " #####\n##### Replies are NOT monitored #####\n"
+                    group_to_send = form.cleaned_data['group']
 
-            else:
-                message_to_send = form.cleaned_data[
-                    'message'] + "\n##### SENT BY: " + "No character but can send pings?" + " TO: " + \
-                    form.cleaned_data['group'] + " WHEN: " + datetime.datetime.utcnow().strftime(
-                    "%Y-%m-%d %H:%M:%S") + " #####\n##### Replies are NOT monitored #####\n"
-                group_to_send = form.cleaned_data['group']
+                OpenfireManager.send_broadcast_message(group_to_send, message_to_send)
 
-                OpenfireManager.send_broadcast_threaded(group_to_send, message_to_send, )
+                messages.success(request, 'Sent jabber broadcast to %s' % group_to_send)
+                logger.info("Sent jabber broadcast on behalf of user %s" % request.user)
+            except PingBotException as e:
+                messages.error(request, e)
 
-            messages.success(request, 'Sent jabber broadcast to %s' % group_to_send)
-            logger.info("Sent jabber broadcast on behalf of user %s" % request.user)
     else:
         form = JabberBroadcastForm()
         form.fields['group'].choices = allchoices


### PR DESCRIPTION
Removes threading. From my discussion with @Adarnof this tool used to manually message each user which would block for a considerable amount of time. Now it uses the broadcast plugin I think its preferable to block until we have some feedback for the user, given that the process may only take a few seconds. If users report that it is taking an exceedingly long time to send broadcasts after this change I'll have to come up with a better solution.

This also includes changes to prevent SleekXMPP from going into an infinite connection attempt loop under certain circumstances. Stopping the infinite connection loops in `runserver` actually required the kill command to stop even after exiting. It was very, very annoying.

Also added a "hidden" option to disable SSL verification to allow users to work around #736. By default this option is disabled and users may enable it at their own peril. Unfortunately its not very easy to return a meaningful error message about the SSL verification error without overriding rather deep components of SleekXMPP.