### PR TITLE
Discord API rate limiting

### DIFF
--- a/alliance_auth/tests/test_settings.py
+++ b/alliance_auth/tests/test_settings.py
@@ -454,12 +454,12 @@ TEAMSPEAK3_PUBLIC_URL = os.environ.get('AA_TEAMSPEAK3_PUBLIC_URL', 'example.com'
 # DISCORD_CALLBACK_URL - oauth callback url
 # DISCORD_SYNC_NAMES - enable to force discord nicknames to be set to eve char name (bot needs Manage Nicknames permission)
 ######################################
-DISCORD_GUILD_ID = os.environ.get('AA_DISCORD_GUILD_ID', '')
-DISCORD_BOT_TOKEN = os.environ.get('AA_DISCORD_BOT_TOKEN', '')
-DISCORD_INVITE_CODE = os.environ.get('AA_DISCORD_INVITE_CODE', '')
-DISCORD_APP_ID = os.environ.get('AA_DISCORD_APP_ID', '')
-DISCORD_APP_SECRET = os.environ.get('AA_DISCORD_APP_SECRET', '')
-DISCORD_CALLBACK_URL = os.environ.get('AA_DISCORD_CALLBACK_URL', 'http://example.com/discord_callback')
+DISCORD_GUILD_ID = os.environ.get('AA_DISCORD_GUILD_ID', '0118999')
+DISCORD_BOT_TOKEN = os.environ.get('AA_DISCORD_BOT_TOKEN', 'bottoken')
+DISCORD_INVITE_CODE = os.environ.get('AA_DISCORD_INVITE_CODE', 'invitecode')
+DISCORD_APP_ID = os.environ.get('AA_DISCORD_APP_ID', 'appid')
+DISCORD_APP_SECRET = os.environ.get('AA_DISCORD_APP_SECRET', 'secret')
+DISCORD_CALLBACK_URL = os.environ.get('AA_DISCORD_CALLBACK_URL', 'http://example.com/discord/callback')
 DISCORD_SYNC_NAMES = 'True' == os.environ.get('AA_DISCORD_SYNC_NAMES', 'False')
 
 ######################################

--- a/services/modules/discord/manager.py
+++ b/services/modules/discord/manager.py
@@ -70,8 +70,8 @@ def api_backoff(func):
 
     @wraps(func)
     def decorated(*args, **kwargs):
-        blocking = True if 'blocking' in kwargs and kwargs['blocking'] == True else False
-        retries = kwargs['max_retries'] if 'max_retries' in kwargs else 3
+        blocking = getattr(kwargs, 'blocking', False)
+        retries = getattr(kwargs, 'max_retries', 3)
 
         # Strip our parameters
         if 'max_retries' in kwargs:

--- a/services/modules/discord/tasks.py
+++ b/services/modules/discord/tasks.py
@@ -9,7 +9,7 @@ from django.core.exceptions import ObjectDoesNotExist
 
 from eveonline.managers import EveManager
 from notifications import notify
-from services.modules.discord.manager import DiscordOAuthManager
+from services.modules.discord.manager import DiscordOAuthManager, DiscordApiBackoff
 from services.tasks import only_one
 from .models import DiscordUser
 
@@ -74,6 +74,10 @@ class DiscordTasks:
             logger.debug("Updating user %s discord groups to %s" % (user, groups))
             try:
                 DiscordOAuthManager.update_groups(user.discord.uid, groups)
+            except DiscordApiBackoff as bo:
+                logger.info("Discord group sync API back off for %s, "
+                            "retrying in %s seconds" % (user, bo.retry_after))
+                raise task_self.retry(countdown=bo.retry_after)
             except Exception as e:
                 if task_self:
                     logger.exception("Discord group sync failed for %s, retrying in 10 mins" % user)

--- a/services/modules/discord/tests.py
+++ b/services/modules/discord/tests.py
@@ -17,6 +17,9 @@ from alliance_auth.tests.auth_utils import AuthUtils
 from .auth_hooks import DiscordService
 from .models import DiscordUser
 from .tasks import DiscordTasks
+from .manager import DiscordOAuthManager
+
+import requests_mock
 
 MODULE_PATH = 'services.modules.discord'
 
@@ -191,3 +194,185 @@ class DiscordViewsTestCase(TestCase):
         self.assertRedirects(response, expected_url='/en/services/', target_status_code=200)
         with self.assertRaises(ObjectDoesNotExist):
             discord_user = User.objects.get(pk=self.member.pk).discord
+
+
+class DiscordManagerTestCase(TestCase):
+
+    def setUp(self):
+        pass
+
+    def test__sanitize_groupname(self):
+        test_group_name = ' Group Name_Test_'
+        group_name = DiscordOAuthManager._sanitize_groupname(test_group_name)
+
+        self.assertEqual(group_name, 'GroupName_Test')
+
+    def test_generate_Bot_add_url(self):
+        from . import manager
+        bot_add_url = DiscordOAuthManager.generate_bot_add_url()
+
+        auth_url = manager.AUTH_URL
+        real_bot_add_url = '{}?client_id=appid&scope=bot&permissions={}'.format(auth_url, manager.BOT_PERMISSIONS)
+        self.assertEqual(bot_add_url, real_bot_add_url)
+
+    def test_generate_oauth_redirect_url(self):
+        from . import manager
+        import urllib
+        import sys
+        oauth_url = DiscordOAuthManager.generate_oauth_redirect_url()
+
+        self.assertIn(manager.AUTH_URL, oauth_url)
+        self.assertIn('+'.join(manager.SCOPES), oauth_url)
+        self.assertIn(settings.DISCORD_APP_ID, oauth_url)
+        if sys.version_info[0] < 3:
+            # Py2
+            self.assertIn(urllib.quote_plus(settings.DISCORD_CALLBACK_URL), oauth_url)
+        else: # Py3
+            self.assertIn(urllib.parse.quote_plus(settings.DISCORD_CALLBACK_URL), oauth_url)
+
+    @mock.patch(MODULE_PATH + '.manager.OAuth2Session')
+    def test__process_callback_code(self, oauth):
+        from . import manager
+        instance = oauth.return_value
+        instance.fetch_token.return_value = {'access_token': 'mywonderfultoken'}
+
+        token = DiscordOAuthManager._process_callback_code('12345')
+
+        self.assertTrue(oauth.called)
+        args, kwargs = oauth.call_args
+        self.assertEqual(args[0], settings.DISCORD_APP_ID)
+        self.assertEqual(kwargs['redirect_uri'], settings.DISCORD_CALLBACK_URL)
+        self.assertTrue(instance.fetch_token.called)
+        args, kwargs = instance.fetch_token.call_args
+        self.assertEqual(args[0], manager.TOKEN_URL)
+        self.assertEqual(kwargs['client_secret'], settings.DISCORD_APP_SECRET)
+        self.assertEqual(kwargs['code'], '12345')
+        self.assertEqual(token['access_token'], 'mywonderfultoken')
+
+    @mock.patch(MODULE_PATH + '.manager.DiscordOAuthManager._process_callback_code')
+    @requests_mock.Mocker()
+    def test_add_user(self, oauth_token, m):
+        from . import manager
+        import json
+
+        # Arrange
+        oauth_token.return_value = {'access_token': 'accesstoken'}
+
+        headers = {'accept': 'application/json', 'authorization': 'Bearer accesstoken'}
+
+        m.register_uri('POST',
+                       manager.DISCORD_URL + '/invites/'+str(settings.DISCORD_INVITE_CODE),
+                       request_headers=headers,
+                       text='{}')
+
+        m.register_uri('GET',
+                       manager.DISCORD_URL + "/users/@me",
+                       request_headers=headers,
+                       text=json.dumps({'id': "123456"}))
+
+        # Act
+        return_value = DiscordOAuthManager.add_user('abcdef')
+
+        # Assert
+        self.assertEqual(return_value, '123456')
+        self.assertEqual(m.call_count, 2)
+
+    @requests_mock.Mocker()
+    def test_delete_user(self, m):
+        from . import manager
+        import json
+
+        # Arrange
+        headers = {'accept': 'application/json', 'authorization': 'Bot ' + settings.DISCORD_BOT_TOKEN}
+
+        user_id = 12345
+        request_url = '{}/guilds/{}/members/{}'.format(manager.DISCORD_URL, settings.DISCORD_GUILD_ID, user_id)
+        m.register_uri('DELETE',
+                       request_url,
+                       request_headers=headers,
+                       text=json.dumps({}))
+
+        # Act
+        result = DiscordOAuthManager.delete_user(user_id)
+
+        # Assert
+        self.assertTrue(result)
+
+        ###
+        # Test 404 (already deleted)
+        # Arrange
+        m.register_uri('DELETE',
+                       request_url,
+                       request_headers=headers,
+                       status_code=404)
+
+        # Act
+        result = DiscordOAuthManager.delete_user(user_id)
+
+        # Assert
+        self.assertTrue(result)
+
+        ###
+        # Test 500 (some random API error)
+        # Arrange
+        m.register_uri('DELETE',
+                       request_url,
+                       request_headers=headers,
+                       status_code=500)
+
+        # Act
+        result = DiscordOAuthManager.delete_user(user_id)
+
+        # Assert
+        self.assertFalse(result)
+
+    @requests_mock.Mocker()
+    def test_update_nickname(self, m):
+        from . import manager
+        import json
+        # Arrange
+        headers = {'content-type': 'application/json', 'authorization': 'Bot ' + settings.DISCORD_BOT_TOKEN}
+
+        user_id = 12345
+        request_url = '{}/guilds/{}/members/{}'.format(manager.DISCORD_URL, settings.DISCORD_GUILD_ID, user_id)
+        m.patch(request_url,
+                request_headers=headers)
+
+        # Act
+        result = DiscordOAuthManager.update_nickname(user_id, 'somenick')
+
+        # Assert
+        self.assertTrue(result)
+
+    @mock.patch(MODULE_PATH + '.manager.DiscordOAuthManager._DiscordOAuthManager__get_group_cache')
+    @requests_mock.Mocker()
+    def test_update_groups(self, group_cache, m):
+        from . import manager
+        import json
+
+        # Arrange
+        groups = ['Member', 'Blue', 'Special Group']
+
+        group_cache.return_value = [{'id': 111, 'name': 'Member'},
+                                    {'id': 222, 'name': 'Blue'},
+                                    {'id': 333, 'name': 'SpecialGroup'},
+                                    {'id': 444, 'name': 'NotYourGroup'}]
+
+        headers = {'content-type': 'application/json', 'authorization': 'Bot ' + settings.DISCORD_BOT_TOKEN}
+        user_id = 12345
+        request_url = '{}/guilds/{}/members/{}'.format(manager.DISCORD_URL, settings.DISCORD_GUILD_ID, user_id)
+
+        m.patch(request_url,
+                request_headers=headers)
+
+        # Act
+        DiscordOAuthManager.update_groups(user_id, groups)
+
+        # Assert
+        self.assertEqual(len(m.request_history), 1)
+        history = json.loads(m.request_history[0].text)
+        self.assertIn('roles', history)
+        self.assertIn(111, history['roles'])
+        self.assertIn(222, history['roles'])
+        self.assertIn(333, history['roles'])
+        self.assertNotIn(444, history['roles'])

--- a/services/modules/discord/tests.py
+++ b/services/modules/discord/tests.py
@@ -11,6 +11,7 @@ from django.test import TestCase, RequestFactory
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.exceptions import ObjectDoesNotExist
+from django.core.cache import cache
 
 from alliance_auth.tests.auth_utils import AuthUtils
 
@@ -20,7 +21,6 @@ from .tasks import DiscordTasks
 from .manager import DiscordOAuthManager
 
 import requests_mock
-import fakeredis
 
 MODULE_PATH = 'services.modules.discord'
 
@@ -345,15 +345,13 @@ class DiscordManagerTestCase(TestCase):
         # Assert
         self.assertTrue(result)
 
-    @mock.patch(MODULE_PATH + '.manager.redis')
     @mock.patch(MODULE_PATH + '.manager.DiscordOAuthManager._DiscordOAuthManager__get_group_cache')
     @requests_mock.Mocker()
-    def test_update_groups(self, group_cache, redis, m):
+    def test_update_groups(self, group_cache, m):
         from . import manager
         import json
 
         # Arrange
-        redis.Redis.return_value = fakeredis.FakeStrictRedis()
         groups = ['Member', 'Blue', 'Special Group']
 
         group_cache.return_value = [{'id': 111, 'name': 'Member'},
@@ -380,15 +378,12 @@ class DiscordManagerTestCase(TestCase):
         self.assertIn(333, history['roles'], 'The group id 333 must be added to the request')
         self.assertNotIn(444, history['roles'], 'The group id 444 must NOT be added to the request')
 
-    @mock.patch(MODULE_PATH + '.manager.redis')
     @mock.patch(MODULE_PATH + '.manager.DiscordOAuthManager._DiscordOAuthManager__get_group_cache')
     @requests_mock.Mocker()
-    def test_update_groups_backoff(self, group_cache, redis, m):
+    def test_update_groups_backoff(self, group_cache, m):
         from . import manager
 
         # Arrange
-        redis.Redis.return_value = fakeredis.FakeStrictRedis()
-
         groups = ['Member']
         group_cache.return_value = [{'id': 111, 'name': 'Member'}]
 

--- a/testing-requirements.txt
+++ b/testing-requirements.txt
@@ -7,3 +7,4 @@ nose>=1.3.7
 django-nose>=1.4.4
 coverage>=4.3.1
 coveralls>=1.1
+requests-mock>=1.2.0


### PR DESCRIPTION
I wrote this a while ago so I'll let my comment do the talking instead:

Decorator Handles HTTP 429 "Too Many Requests" messages from the Discord API.
If blocking=True is specified, this function will block and retry the function up to max_retries=n times, or 3 if retries is not specified. If the API call still recieves a backoff timer this function will raise a <DiscordApiTooBusy> exception. If the caller chooses blocking=False, the decorator will raise a DiscordApiBackoff exception and the caller can choose to retry after the given timespan available in the retry_after property in seconds.

It doesn't fully handle discords rate limiting headers, instead prevents repeated hits on the API after a 429 backoff has been served. It's also currently only servicing the groups endpoint as that one is, by far, the most likely to receive a 429. The rate limiting function considers the calling function the "route" and stores the per-route backoff against that function name. Global rate limiting is also supported, but not applied against all routes, so its still possible to violate the global rate limit for those.

Also looks like I added a bunch of unit tests for discord manager functions.

tl;dr: Its not perfect, but it should at least get the groups/roles endpoint out of trouble for now.

I haven't got access to a discord server that would hit the rate limit anymore, so if some people want to beta test this, that would be awesome.

Should mostly address #595