### PR TITLE
Determine paths to commands using shutil

### DIFF
--- a/allianceauth/bin/allianceauth.py
+++ b/allianceauth/bin/allianceauth.py
@@ -1,79 +1,57 @@
 #!/usr/bin/env python
 import os
-import sys
+import shutil
 from optparse import OptionParser
-from django.core.management import ManagementUtility
+from django.core.management import call_command
+from django.core.management.commands.startproject import Command as StartProject
 
 
 def create_project(parser, options, args):
     # Validate args
     if len(args) < 2:
-        parser.error("Please specify a name for your Alliance Auth installation")
+        parser.error("Please specify a name for your Alliance Auth installation.")
     elif len(args) > 3:
-        parser.error("Too many arguments")
-
-    project_name = args[1]
-    try:
-        dest_dir = args[2]
-    except IndexError:
-        dest_dir = None
-
-    # Make sure given name is not already in use by another python package/module.
-    try:
-        __import__(project_name)
-    except ImportError:
-        pass
-    else:
-        parser.error("'%s' conflicts with the name of an existing "
-                     "Python module and cannot be used as a project "
-                     "name. Please try another name." % project_name)
-
-    print("Creating an Alliance Auth project called %(project_name)s" % {'project_name': project_name})  # noqa
-
-    # Create the project from the Alliance Auth template using startapp
+        parser.error("Too many arguments.")
 
     # First find the path to Alliance Auth
     import allianceauth
     allianceauth_path = os.path.dirname(allianceauth.__file__)
     template_path = os.path.join(allianceauth_path, 'project_template')
 
-    # Call django-admin startproject
-    utility_args = ['django-admin.py',
-                    'startproject',
-                    '--template=' + template_path,
-                    '--pythonpath=' + '/'.join(sys.executable.split('/')[:-1]),
-                    '--ext=conf',
-                    project_name]
+    # Determine locations of commands to render supervisor cond
+    command_options = {
+        'template': template_path,
+        'python': shutil.which('python'),
+        'gunicorn': shutil.which('gunicorn'),
+        'celery': shutil.which('celery'),
+        'extensions': ['py', 'conf'],
+    }
 
-    if dest_dir:
-        utility_args.append(dest_dir)
+    # Strip 'start' out of the arguments, leaving project name (and optionally destination dir)
+    args = args[1:]
 
-    utility = ManagementUtility(utility_args)
-    utility.execute()
+    # Call the command with extra context
+    call_command(StartProject(), *args, **command_options)
 
-    print("Success! %(project_name)s has been created" % {'project_name': project_name})  # noqa
+    print("Success! %(project_name)s has been created." % {'project_name': args[0]})  # noqa
 
 
 def update_settings(parser, options, args):
     if len(args) < 2:
-        parser.error("Please specify the path to your Alliance Auth installation")
+        parser.error("Please specify the path to your Alliance Auth installation.")
     elif len(args) > 2:
-        parser.error("Too many arguments")
+        parser.error("Too many arguments.")
 
     project_path = args[1]
+    project_name = os.path.split(project_path)[-1]
 
     # find the target settings/base.py file, handing both the project and app as valid paths
-    try:
-        # given path is to the app
-        settings_path = os.path.join(project_path, 'settings/base.py')
-        assert os.path.exists(settings_path)
-    except AssertionError:
-        try:
-            # given path is to the project, so find the app within it
-            dirname = os.path.split(project_path)[-1]
-            settings_path = os.path.join(project_path, dirname, 'settings/base.py')
-            assert os.path.exists(settings_path)
-        except AssertionError:
+    # first check if given path is to the app
+    settings_path = os.path.join(project_path, 'settings/base.py')
+    if not os.path.exists(settings_path):
+        # next check if given path is to the project, so the app is within it
+        settings_path = os.path.join(project_path, project_name, 'settings/base.py')
+        if not os.path.exists(settings_path):
             parser.error("Unable to locate the Alliance Auth project at %s" % project_path)
 
     # first find the path to the Alliance Auth template settings
@@ -83,11 +61,10 @@ def update_settings(parser, options, args):
     template_settings_path = os.path.join(template_path, 'project_name/settings/base.py')
 
     # overwrite the local project's base settings
-    print("Updating the settings at %s with the template at %s" % (settings_path, template_settings_path))
     with open(template_settings_path, 'r') as template, open(settings_path, 'w') as target:
         target.write(template.read())
 
-    print("Successfully updated Alliance Auth settings.")
+    print("Successfully updated %(project_name)s settings." % {'project_name': project_name})
 
 
 COMMANDS = {

--- a/allianceauth/project_template/supervisor.conf
+++ b/allianceauth/project_template/supervisor.conf
@@ -1,5 +1,5 @@
 [program:beat]
-command={{ pythonpath}}/celery -A {{ project_name }} beat
+command={{ celery }} -A {{ project_name }} beat
 directory={{ project_directory }}
 user=allianceserver
 stdout_logfile={{ project_directory }}/log/beat.log
@@ -10,7 +10,7 @@ startsecs=10
 priority=998
 
 [program:worker]
-command={{ pythonpath}}/celery -A {{ project_name }} worker
+command={{ celery }} -A {{ project_name }} worker
 directory={{ project_directory }}
 user=allianceserver
 numprocs=1
@@ -26,7 +26,7 @@ priority=998
 [program:gunicorn]
 user = allianceserver
 directory={{ project_directory }}
-command={{ pythonpath}}/gunicorn {{ project_name}}.wsgi --workers=3 --timeout 120
+command={{ gunicorn }} {{ project_name }}.wsgi --workers=3 --timeout 120
 autostart=true
 autorestart=true
 stopsignal=INT


### PR DESCRIPTION
By guessing paths to commands based off the python location, installs not in a virtualenv would fail to generate a supervisor conf with the correct path to `/usr/local/bin/celery` (and gunicorn), instead guessing `/usr/bin/celery` because that's the folder where python is found.

Using [py3's `shutil` library](https://docs.python.org/3/library/shutil.html) it's possible to get the full path to an arbitrary command using [`shutil.which('celery')`](https://docs.python.org/3/library/shutil.html#shutil.which). This means it can tolerate installing inside a venv, globally, and even using development packages installed with `pip install -e`.

Calling the `django-admin startproject` command within `allianceauth start` prevented us from passing custom context to template rendering - this is why the `pythonpath` context had been hijacked to pass the directory where it was guessed celery and gunicorn resided. I have no idea what the consequences of that could be. Bypassing the command line and calling it directly using `django.core.management.call_command`, passing `django.core.management.commands.startproject.Command` instead of a string name, skips the option parser validation allowing the injection of arbitrary contexts to template rendering. Using this three new contexts are passed, `python`, `celery`, and `gunicorn` which are the paths determined using `shutil.which` to allow for proper supervisor conf rendering.

I've removed some argument validation as the startproject command does this validation already, albeit returning a traceback in addition to the error message instead of just our custom error message, but I hate duplicating code so it had to go.