### PR TITLE
Remove trailing , from CELERYBEAT_SCHEDULE example.

### DIFF
--- a/docs/features/corpstats.md
+++ b/docs/features/corpstats.md
@@ -116,7 +116,7 @@ By default Corp Stats are only updated on demand. If you want to automatically r
     CELERYBEAT_SCHEDULE['update_all_corpstats'] = {
         'task': 'allianceauth.corputils.tasks.update_all_corpstats',
         'schedule': crontab(minute=0, hour="*/6"),
-    },
+    }
 
 Adjust the crontab as desired.
 


### PR DESCRIPTION
If a user copies the example verbatim, celery logs this error:
```
[2018-04-07 14:57:29,930: ERROR/MainProcess] Cannot add entry 'update_all_corpstats' to database schedule: TypeE rror('from_entry() argument after ** must be a mapping, not tuple',). Contents: ({'task': 'allianceauth.corputil s.tasks.update_all_corpstats', 'schedule': <crontab: 0 */6 * * * (m/h/d/dM/MY)>},)
```