### PR TITLE
Fix 429 spam on discord update_all_nicknames

### DIFF
--- a/allianceauth/services/modules/discord/manager.py
+++ b/allianceauth/services/modules/discord/manager.py
@@ -219,22 +219,18 @@ class DiscordOAuthManager:
     @staticmethod
     @api_backoff
     def update_nickname(user_id, nickname):
-        try:
-            nickname = DiscordOAuthManager._sanitize_name(nickname)
-            custom_headers = {'content-type': 'application/json', 'authorization': 'Bot ' + settings.DISCORD_BOT_TOKEN}
-            data = {'nick': nickname}
-            path = DISCORD_URL + "/guilds/" + str(settings.DISCORD_GUILD_ID) + "/members/" + str(user_id)
-            r = requests.patch(path, headers=custom_headers, json=data)
-            logger.debug("Got status code %s after setting nickname for Discord user ID %s (%s)" % (
-                r.status_code, user_id, nickname))
-            if r.status_code == 404:
-                logger.warn("Discord user ID %s could not be found in server." % user_id)
-                return True
-            r.raise_for_status()
+        nickname = DiscordOAuthManager._sanitize_name(nickname)
+        custom_headers = {'content-type': 'application/json', 'authorization': 'Bot ' + settings.DISCORD_BOT_TOKEN}
+        data = {'nick': nickname}
+        path = DISCORD_URL + "/guilds/" + str(settings.DISCORD_GUILD_ID) + "/members/" + str(user_id)
+        r = requests.patch(path, headers=custom_headers, json=data)
+        logger.debug("Got status code %s after setting nickname for Discord user ID %s (%s)" % (
+            r.status_code, user_id, nickname))
+        if r.status_code == 404:
+            logger.warn("Discord user ID %s could not be found in server." % user_id)
             return True
-        except:
-            logger.exception("Failed to set nickname for Discord user ID %s (%s)" % (user_id, nickname))
-            return False
+        r.raise_for_status()
+        return True
 
     @staticmethod
     def delete_user(user_id):


### PR DESCRIPTION
I noticed this wasn't working and when I dug down to have a look I noticed that the function in `manager.py` just returns when HTTP status is raised. This suppresses the `@api_backoff` wrapper since it's trying to catch an HTTP Exception.

I believe just taking out the try block should fix the issue.